### PR TITLE
Add support for not showing stages and allow user entry of build count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules/
 /sdk/node_modules/
+*.vsix

--- a/configuration.html
+++ b/configuration.html
@@ -1,6 +1,17 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
+    <style>
+        .input{
+            display: inline-block;
+            position: relative;
+            width: 100%;
+            border:  1px solid;
+            border-color: rgba( 234, 234, 234 ,  1 );
+            border-color: rgba( var(--palette-neutral-8,234, 234, 234) ,  1 );
+            padding: 1px 0;
+        }
+    </style>
 </head>
 <body>
 <div class="widget-configuration">
@@ -18,19 +29,19 @@
     </fieldset>
     <fieldset>
         <label class="label">Build count: </label>
-        <select id="build-count-dropdown" class="dropdown" style="margin-top:10px">
-            <option value="5" selected>5</option>
-            <option value="6">6</option>
-            <option value="7">7</option>
-            <option value="8">8</option>
-            <option value="9">9</option>
-            <option value="10">10</option>
-        </select>
+        <input type="number" min="1" max="50" id="build-count" class="input" style="margin-top:10px">
     </fieldset>
     <fieldset>
         <label class="label">Default tag</label>
         <select id="build-default-tag-dropdown" class="dropdown" style="margin-top:10px">
             <option value="all" selected>all</option>
+        </select>
+    </fieldset>
+    <fieldset>
+        <label class="label">Show stages:</label>
+        <select id="show-stages" class="dropdown" style="margin-top:10px">
+            <option value="true" selected>Yes</option>
+            <option value="false">No</option>
         </select>
     </fieldset>
 </div>

--- a/scripts/configuration.js
+++ b/scripts/configuration.js
@@ -7,9 +7,10 @@ let projectId = "";
 
 let buildDropdown = document.getElementById("build-dropdown");
 let branchDropdown = document.getElementById("branch-dropdown");
-let buildCountDropdown = document.getElementById("build-count-dropdown");
+let buildCountInput = document.getElementById("build-count");
 let defaultTagDropdown = document.getElementById("build-default-tag-dropdown")
 let defaultBranchDropdownOptions = '<option value="" selected disabled hidden>Please select a query</option>';
+let showStagesDropdown = document.getElementById("show-stages");
 
 /**
  * @description Add definition names to the build definition dropdown
@@ -134,8 +135,9 @@ function onBranchDropdownChange(WidgetHelpers, widgetConfigurationContext, defin
             buildDefinition: buildDropdown.value,
             buildBranch: branchDropdown.value,
             definitionName: definition.name,
-            buildCount: buildCountDropdown.value,
-            defaultTag: defaultTagDropdown.value
+            buildCount: buildCountInput.value,
+            defaultTag: defaultTagDropdown.value,
+            showStages: showStagesDropdown.value,
         })
     };
     let eventName = WidgetHelpers.WidgetEvent.ConfigurationChange;
@@ -143,7 +145,7 @@ function onBranchDropdownChange(WidgetHelpers, widgetConfigurationContext, defin
     widgetConfigurationContext.notify(eventName, eventArgs);
 }
 
-function onBuildCountDropdownChange(WidgetHelpers, widgetConfigurationContext, definitions) {
+function onBuildCountInputChange(WidgetHelpers, widgetConfigurationContext, definitions) {
     if (branchDropdown.value !== "" && buildDropdown.value != "") {
         let definition = definitions.filter(definition => definition.id == buildDropdown.value)[0];
         console.log(`Selected to display ${buildDropdown.value} for branch ${branchDropdown.value} and definition ${definition.name}`);
@@ -152,8 +154,9 @@ function onBuildCountDropdownChange(WidgetHelpers, widgetConfigurationContext, d
                 buildDefinition: buildDropdown.value,
                 buildBranch: branchDropdown.value,
                 definitionName: definition.name,
-                buildCount: buildCountDropdown.value,
-                defaultTag: defaultTagDropdown.value
+                buildCount: buildCountInput.value,
+                defaultTag: defaultTagDropdown.value,
+                showStages: showStagesDropdown.value,
             })
         };
         let eventName = WidgetHelpers.WidgetEvent.ConfigurationChange;
@@ -171,14 +174,33 @@ function onDefaultTagDropdownChange(WidgetHelpers, widgetConfigurationContext, d
                 buildDefinition: buildDropdown.value,
                 buildBranch: branchDropdown.value,
                 definitionName: definition.name,
-                buildCount: buildCountDropdown.value,
-                defaultTag: defaultTagDropdown.value
+                buildCount: buildCountInput.value,
+                defaultTag: defaultTagDropdown.value,
+                showStages: showStagesDropdown.value,
             })
         };
         let eventName = WidgetHelpers.WidgetEvent.ConfigurationChange;
         let eventArgs = WidgetHelpers.WidgetEvent.Args(customSettings);
         widgetConfigurationContext.notify(eventName, eventArgs);
     }
+}
+
+function onShowStagesDropdownChange(WidgetHelpers, widgetConfigurationContext, definitions) {
+  let definition = definitions.filter((definition) => definition.id == buildDropdown.value)[0];
+  let customSettings = {
+    data: JSON.stringify({
+      buildDefinition: buildDropdown.value,
+      buildBranch: branchDropdown.value,
+      definitionName: definition.name,
+      buildCount: buildCountInput.value,
+      defaultTag: defaultTagDropdown.value,
+      showStages: showStagesDropdown.value,
+    }),
+  };
+  
+  let eventName = WidgetHelpers.WidgetEvent.ConfigurationChange;
+  let eventArgs = WidgetHelpers.WidgetEvent.Args(customSettings);
+  widgetConfigurationContext.notify(eventName, eventArgs);
 }
 
 /**
@@ -202,8 +224,9 @@ function saveSettings(WidgetHelpers, definitions)
             buildDefinition: buildDropdown.value,
             buildBranch: branchDropdown.value,
             definitionName: definition.name,
-            buildCount: buildCountDropdown.value,
-            defaultTag: defaultTagDropdown.value
+            buildCount: buildCountInput.value,
+            defaultTag: defaultTagDropdown.value,
+            showStages: showStagesDropdown.value,
         })
     };
 
@@ -254,7 +277,7 @@ VSS.require(["TFS/Dashboards/WidgetHelpers", "VSS/Service", "TFS/Build/RestClien
                         console.log(`Settings have been found and validated. Current settings are: 
                             ${JSON.stringify(settings)}`);
                         buildDropdown.value = settings.buildDefinition;
-                        buildCountDropdown.value = settings.buildCount;
+                        buildCountInput.value = settings.buildCount;
                         let buildDefinition = settings.buildDefinition;
 
 
@@ -271,6 +294,9 @@ VSS.require(["TFS/Dashboards/WidgetHelpers", "VSS/Service", "TFS/Build/RestClien
                     else {
                         console.log("Settings are either not present or valid. This will be a first setup for the configuration.");
                     }
+                    if (settings.showStages != true) {
+                      showStagesDropdown.value = "false";
+                    }
                     //Create a json object and pass it as widget settings
                     buildDropdown.onchange = async function () {
                         await onBuildDropdownChange(definitions, codeClient);
@@ -278,14 +304,17 @@ VSS.require(["TFS/Dashboards/WidgetHelpers", "VSS/Service", "TFS/Build/RestClien
                     branchDropdown.onchange = function()
                     {
                         onBranchDropdownChange(WidgetHelpers, widgetConfigurationContext, definitions);
-                    }
-                    buildCountDropdown.onchange = function () {
-                        onBuildCountDropdownChange(WidgetHelpers, widgetConfigurationContext, definitions);
-                    }
+                    };
+                    buildCountInput.onchange = function () {
+                        onBuildCountInputChange(WidgetHelpers, widgetConfigurationContext, definitions);
+                    };
 
                     defaultTagDropdown.onchange = function () {
                         onDefaultTagDropdownChange(WidgetHelpers, widgetConfigurationContext, definitions);
-                    }
+                    };
+                    showStagesDropdown.onchange = function () {
+                      onShowStagesDropdownChange(WidgetHelpers, widgetConfigurationContext, definitions);
+                    };
 
                     return WidgetHelpers.WidgetStatusHelper.Success();
                 },

--- a/vss-extension-devel.json
+++ b/vss-extension-devel.json
@@ -31,6 +31,10 @@
         "uri": "widget.html",
         "supportedSizes": [
           {
+            "rowSpan": 1,
+            "columnSpan": 2
+          },
+          {
             "rowSpan": 2,
             "columnSpan": 3
           },

--- a/widget.html
+++ b/widget.html
@@ -5,7 +5,7 @@
 
     </head>
     <body>
-        <div class="widget">
+        <div class="widget" style="scrollbar-width: none; overflow: scroll;">
             <div id="widget-container">
 
                 <h2 class="title">


### PR DESCRIPTION
This PR adds support for:
 - Showing overall build status rather than all stages. This means users can have more compact dashboards if builds have many stages in a pipeline.
 - Freeform input for the build count. I have preliminarily set a maximum of 50 as otherwise it will probably get overcrowded.
 - Scrolling within the widget. This is useful when the build count is high and overflows the size of the widget.
 - 1x2 Size for the widget. This allows for compact dashboards when not showing stage information.

Hopefully this is acceptable, but please let me know if there is anything you need to get this merged. Thanks!