### PR TITLE
Move the default value of number of builds to the hmtl field

### DIFF
--- a/configuration.html
+++ b/configuration.html
@@ -29,7 +29,7 @@
     </fieldset>
     <fieldset>
         <label class="label">Build count: </label>
-        <input type="number" min="1" max="50" id="build-count" class="input" style="margin-top:10px">
+        <input type="number" min="1" max="50" value="5" id="build-count" class="input" style="margin-top:10px">
     </fieldset>
     <fieldset>
         <label class="label">Default tag</label>


### PR DESCRIPTION
During the first configure of the control it's clearer how many builds will be taken by default, and imho it's nicer to have always a value in this field