### PR TITLE
Fix "Show stages" reload not working in the configuration widget and fix the size of each dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-devops-extension-sample",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Sample Azure DevOps web extension",
   "keywords": [
     "extensions",
@@ -29,7 +29,7 @@
     "azure-devops-extension-api": "^4.241.1",
     "azure-devops-extension-sdk": "^4.0.2",
     "azure-devops-ui": "^2.238.0",
-    "react": "~16.14.0",
+    "react": "~16.13.1",
     "react-dom": "~16.13.1"
   },
   "devDependencies": {

--- a/src/Components/BuildResultRow.tsx
+++ b/src/Components/BuildResultRow.tsx
@@ -14,6 +14,15 @@ export class BuildResultRow extends React.Component<IBuildResultRowProps, BuildR
         this.state = BuildResultRowState.createStateFromProperties(props);
     }
 
+    static getDerivedStateFromProps(nextProps: IBuildResultRowProps, prevState: BuildResultRowState) {
+        if(prevState.showStages !== nextProps.showStages) {
+            return {
+                showStages: nextProps.showStages
+            } as BuildResultRowState;
+        }
+        return null;
+    }
+
     /**
      * Converts a build result into a task result
      * @param buildResult The build result to convert

--- a/src/widget.css
+++ b/src/widget.css
@@ -134,6 +134,10 @@ a {
     margin:  1em;
 }
 
+.dropdown-element input {
+    width: 10em;
+}
+
 .widget-tag-container {
 
     width: 100%;
@@ -141,7 +145,7 @@ a {
 
 .widget-tag-dropdown {
     float: right;
-    width: 15em;
+    width: 15em !important;
 }
 
 /*


### PR DESCRIPTION
- Downgrade react version to 16.13.1 as it is breaking logging and debugging for subcomponents.

- Update dropdowns css to make them bigger by default and of fixed size

- Fixed a bug where BuildResultRow.tsx would not re-render anymore by implementing `getDerivedStateFromProps`